### PR TITLE
deduplicate client urls

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"go.etcd.io/etcd/client/pkg/v3/srv"
+	"golang.org/x/exp/slices"
 )
 
 func endpointsWithLeaderAtEnd(gcfg globalConfig, statusList []epStatus) ([]string, error) {
@@ -49,6 +50,9 @@ func endpointsFromCluster(gcfg globalConfig) ([]string, error) {
 	for _, m := range memberlistResp.Members {
 		eps = append(eps, m.ClientURLs...)
 	}
+
+	slices.Sort(eps)
+	eps = slices.Compact(eps)
 
 	return eps, nil
 }

--- a/endpoints_test.go
+++ b/endpoints_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"golang.org/x/exp/slices"
+)
+
+func TestEndpointDedup(t *testing.T) {
+	oldCreateClient := createClient
+	t.Cleanup(func() {
+		createClient = oldCreateClient
+	})
+
+	fakeClient := fakeClientURLClient{}
+	createClient = func(cfgSpec *clientv3.ConfigSpec) (EtcdCluster, error) {
+		return &fakeClient, nil
+	}
+
+	testcases := []struct {
+		name               string
+		returnedMemberList *clientv3.MemberListResponse
+		expectedEndpoints  []string
+	}{
+		{
+			"normal",
+			&clientv3.MemberListResponse{
+				Members: []*etcdserverpb.Member{
+					{
+						ClientURLs: []string{"etcd1.example.com:2379"},
+					},
+					{
+						ClientURLs: []string{"etcd2.example.com:2379"},
+					},
+					{
+						ClientURLs: []string{"etcd3.example.com:2379"},
+					},
+				},
+			},
+			[]string{"etcd1.example.com:2379", "etcd2.example.com:2379", "etcd3.example.com:2379"},
+		},
+		{
+			"sort",
+			&clientv3.MemberListResponse{
+				Members: []*etcdserverpb.Member{
+					{
+						ClientURLs: []string{"etcd1.example.com:2379"},
+					},
+					{
+						ClientURLs: []string{"etcd3.example.com:2379"},
+					},
+					{
+						ClientURLs: []string{"etcd2.example.com:2379"},
+					},
+				},
+			},
+			[]string{"etcd1.example.com:2379", "etcd2.example.com:2379", "etcd3.example.com:2379"},
+		},
+		{
+			"uniq",
+			&clientv3.MemberListResponse{
+				Members: []*etcdserverpb.Member{
+					{
+						ClientURLs: []string{"etcd1.example.com:2379", "etcd.example.com:2379"},
+					},
+					{
+						ClientURLs: []string{"etcd3.example.com:2379", "etcd.example.com:2379"},
+					},
+					{
+						ClientURLs: []string{"etcd2.example.com:2379", "etcd.example.com:2379"},
+					},
+				},
+			},
+			[]string{"etcd.example.com:2379", "etcd1.example.com:2379", "etcd2.example.com:2379", "etcd3.example.com:2379"},
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			fakeClient.memberListResp = testcase.returnedMemberList
+			ep, err := endpointsFromCluster(globalConfig{endpoints: []string{"https://localhost:2379"}})
+			if err != nil {
+				t.Error(err)
+			}
+
+			if !slices.Equal(testcase.expectedEndpoints, ep) {
+				t.Errorf("endpoints didn't match. Expected %v got %v", testcase.expectedEndpoints, ep)
+			}
+		})
+	}
+}
+
+type fakeClientURLClient struct {
+	*clientv3.Client
+	memberListResp *clientv3.MemberListResponse
+}
+
+// MemberList lists the current cluster membership.
+func (f fakeClientURLClient) MemberList(ctx context.Context, opts ...clientv3.OpOption) (*clientv3.MemberListResponse, error) {
+	return f.memberListResp, nil
+}
+
+func (fakeClientURLClient) Close() error {
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
 	golang.org/x/text v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,7 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -61,6 +62,7 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/maja42/goval v1.3.1 h1:F/3Qqi0DX0VO9pVGuzbPVVI9WDI5L8muzMt+OAjh1xw=
 github.com/maja42/goval v1.3.1/go.mod h1:LDMwF8ocOwIsMZdwoyHC/3UpV8ABDwEzalxkVV2z/rI=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -95,6 +97,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b h1:r+vk0EmXNmekl0S0BascoeeoHk/L7wmaW2QF90K+kYI=
+golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/utils.go
+++ b/utils.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"io"
 	"time"
 
 	"go.uber.org/zap"
@@ -14,7 +15,15 @@ func commandCtx(timeout time.Duration) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), timeout)
 }
 
-func createClient(cfgSpec *clientv3.ConfigSpec) (*clientv3.Client, error) {
+// EtcdCluster composes the interfaces needed to interact with the cluster. It mainly exist to enable testing.
+type EtcdCluster interface {
+	clientv3.Maintenance
+	clientv3.Cluster
+	clientv3.KV
+	io.Closer
+}
+
+var createClient = func(cfgSpec *clientv3.ConfigSpec) (EtcdCluster, error) {
 	lg, _ := logutil.CreateDefaultZapLogger(zap.InfoLevel)
 	cfg, err := clientv3.NewClientConfig(cfgSpec, lg)
 	if err != nil {


### PR DESCRIPTION
When providing a list of endpoints the defrag program lists all the client urls to perform a healthcheck. In some deployments every etcd instance exposes the same cluster wide endpoints in combination with its pod hostname:

```
etcdctl --cert etcd.pem --key etcd-key.pem --cacert ca.pem --endpoints https://etcd-0:2379 member list -w table
    +------------------+---------+--------+-------------------------------------------------------------------+---------------------------------------------------------------------------------------------------+------------+
    |        ID        | STATUS  |  NAME  |                            PEER ADDRS                             |                                                    CLIENT ADDRS                                   | IS LEARNER |
    +------------------+---------+--------+-------------------------------------------------------------------+---------------------------------------------------------------------------------------------------+------------+
    | 4e5e63301fb04046 | started | etcd-2 | https://etcd-2.etcd-headless.cluster.svc.cluster.local:2380 | https://etcd-2.etcd-headless.cluster.svc.cluster.local:2379,https://etcd.cluster.svc.cluster.local:2379 |      false |
    | 57c4758cb4693082 | started | etcd-1 | https://etcd-1.etcd-headless.cluster.svc.cluster.local:2380 | https://etcd-1.etcd-headless.cluster.svc.cluster.local:2379,https://etcd.cluster.svc.cluster.local:2379 |      false |
    | 5a2b185c02a1587e | started | etcd-0 | https://etcd-0.etcd-headless.cluster.svc.cluster.local:2380 | https://etcd-0.etcd-headless.cluster.svc.cluster.local:2379,https://etcd.cluster.svc.cluster.local:2379 |      false |
    +------------------+---------+--------+-------------------------------------------------------------------+---------------------------------------------------------------------------------------------------+------------+
```

Only 1 healthcheck (if any) needs to be performed for this endpoint.