### PR TITLE
Feat/docker builds

### DIFF
--- a/.github/workflows/etcd-defrag.yaml
+++ b/.github/workflows/etcd-defrag.yaml
@@ -1,0 +1,30 @@
+name: Publish
+
+on:
+- push
+- workflow_dispatch
+
+jobs:
+  goversion:
+    uses: ./.github/workflows/go-version.yaml
+  publish-tagged:
+    if: |
+      startsWith(github.ref, 'refs/tags/v') &&
+      !github.event.pull_request.head.repo.fork
+    runs-on: ubuntu-latest
+    needs: goversion
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ needs.goversion.outputs.goversion }}
+      - uses: ko-build/setup-ko@v0.6
+        name: Setup ko
+      - name: Run ko publish for ghcr.io
+        env:
+          KO_DOCKER_REPO: ghcr.io/${{ github.repository_owner }}
+        run: |
+          export COMMIT=${{ github.sha}}
+          export TAG=$(echo ${{ github.ref }} | cut -d "/" -f 3 - )
+          ko publish ./ --base-import-paths --platform=linux/amd64,linux/arm64 --tags $TAG
+          ko publish ./ --base-import-paths --platform=linux/amd64,linux/arm64

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,9 @@
+builds:
+- id: etcd-defrag
+  dir: .
+  main: ./
+  env:
+  - CGO_ENABLED=0
+  ldflags:
+  - -X main.Version={{.Env.TAG}}
+  - -X main.GitSHA={{.Env.COMMIT}}


### PR DESCRIPTION
I've added simple docker builds using [`ko-build/ko`](https://github.com/ko-build/ko), I think it would quite useful to have docker images available.

let me know if you want me to adapt the README.

also, if this gets merged, I'll create another PR with a Kubernetes `CronJob` using the docker image to defragment my etcd clusters.

thanks for the tool by the way! really useful :)