### PR TITLE
fix : Evaluation result log shouldn't be send to stderr

### DIFF
--- a/main.go
+++ b/main.go
@@ -138,7 +138,7 @@ func defragCommandFunc(cmd *cobra.Command, args []string) {
 				}
 				continue
 			}
-			fmt.Fprintf(os.Stderr, "Evaluation result is false, so skipping endpoint: %s\n", ep)
+			fmt.Printf("Evaluation result is false, so skipping endpoint: %s\n", ep)
 			continue
 		}
 


### PR DESCRIPTION
Actually, this log is no't an error and can be perform in stdout.