### PR TITLE
Bump go version to 1.21.9 to address CVE-2023-45288

### DIFF
--- a/.github/workflows/go-version.yaml
+++ b/.github/workflows/go-version.yaml
@@ -1,7 +1,7 @@
 name: Go version setup
 
 env:
-  GO_VERSION: "1.21.8"
+  GO_VERSION: "1.21.9"
 
 on:
   workflow_call:


### PR DESCRIPTION
FYI. https://pkg.go.dev/vuln/GO-2024-2687