### PR TITLE
overwrite OCI source label in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,3 +4,5 @@ FROM --platform=linux/${ARCH} gcr.io/distroless/static-debian11
 ADD etcd-defrag /usr/local/bin/
 
 CMD ["/usr/local/bin/etcd-defrag"]
+
+LABEL org.opencontainers.image.source="https://github.com/ahrtr/etcd-defrag"


### PR DESCRIPTION
Currently, this label is set to
`https://github.com/chainguard-images/images/tree/main/images/static` (because the ko base image is this chainguard image).

This leads to issues with dependency managers like renovate, which uses this label to parse the change log.

Setting this label to the correct source URL fixes such problems.

More Information on those labels:

https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys

https://github.com/ko-build/ko/issues/1395

https://docs.renovatebot.com/modules/datasource/docker/#description