### PR TITLE
overwrite OCI source label in image

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,5 +26,9 @@ jobs:
         run: |
           export COMMIT=${{ github.sha}}
           export TAG=$(echo ${{ github.ref }} | cut -d "/" -f 3 - )
-          ko publish ./ --base-import-paths --platform=linux/amd64,linux/arm64 --tags $TAG
-          ko publish ./ --base-import-paths --platform=linux/amd64,linux/arm64
+          ko publish ./ --base-import-paths --platform=linux/amd64,linux/arm64 --tags latest,$TAG \
+            --image-label org.opencontainers.image.source="https://github.com/ahrtr/etcd-defrag" \
+            --image-label org.opencontainers.image.created="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+            --image-label org.opencontainers.image.authors="ahrtr" \
+            --image-label org.opencontainers.image.url="https://ghcr.io/ahrtr/etcd-defrag" \
+            --image-label org.opencontainers.image.vendor="ahrtr"


### PR DESCRIPTION
Currently, this label is set to
`https://github.com/chainguard-images/images/tree/main/images/static` (because the ko base image is this chainguard image).

This leads to issues with dependency managers like renovate, which uses this label to parse the change log.

Setting this label to the correct source URL fixes such problems.

More Information on those labels:

https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys

https://github.com/ko-build/ko/issues/1395

https://docs.renovatebot.com/modules/datasource/docker/#description