### PR TITLE
Add leader transfer logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ It adds the following extra flags,
 | `--defrag-rule`              | defragmentation rule (etcd-defrag will run defragmentation if the rule is empty or it is evaluated to true), defaults to empty. See more details below. |
 | `--dry-run`                  | evaluate whether or not endpoints require defragmentation, but don't actually perform it, defaults to `false`. |
 | `--exclude-localhost`        | whether to exclude localhost endpoints, defaults to `false`. |
+| `--move-leader`              | whether to move the leader to a randomly picked non-leader ID and make it the new leader, defaults to `false`. |
 
 See the complete flags below,
 ```
@@ -70,6 +71,7 @@ Flags:
       --keepalive-time duration        keepalive time for client connections (default 2s)
       --keepalive-timeout duration     keepalive timeout for client connections (default 6s)
       --key string                     identify secure client using this TLS key file
+      --move-leader                    whether to move the leader to a randomly picked non-leader ID and make it the new leader
       --password string                password for authentication (if this option is used, --user option shouldn't include password)
       --user string                    username[:password] for authentication (prompt if password is not supplied)
       --version                        print the version and exit

--- a/agent.go
+++ b/agent.go
@@ -234,7 +234,6 @@ func transferLeadership(gcfg globalConfig, leaderEp string, newLeader epStatus) 
 	}
 	defer c.Close()
 
-	// Step 3: Use the MoveLeader method to transfer leadership
 	ctx, cancel := commandCtx(gcfg.commandTimeout)
 	defer cancel()
 
@@ -244,7 +243,6 @@ func transferLeadership(gcfg globalConfig, leaderEp string, newLeader epStatus) 
 		return fmt.Errorf("failed to move leader: %w", err)
 	}
 
-	// Step 4: Confirm success
 	fmt.Println("successfully transferred leadership from", leaderEp, "to", newLeader.Ep)
 	return nil
 }

--- a/agent.go
+++ b/agent.go
@@ -225,7 +225,7 @@ func defragment(gcfg globalConfig, ep string) error {
 	return err
 }
 
-func transferLeadership(gcfg globalConfig, leaderEp string, newLeader epStatus) error {
+func transferLeadership(gcfg globalConfig, leaderEp string, transfereeID uint64) error {
 	cfgSpec := clientConfigWithoutEndpoints(gcfg)
 	cfgSpec.Endpoints = []string{leaderEp}
 	c, err := createClient(cfgSpec)
@@ -237,12 +237,12 @@ func transferLeadership(gcfg globalConfig, leaderEp string, newLeader epStatus) 
 	ctx, cancel := commandCtx(gcfg.commandTimeout)
 	defer cancel()
 
-	fmt.Printf("Requesting leader at %s to transfer leadership to %s...\n", leaderEp, newLeader.Ep)
-	_, err = c.MoveLeader(ctx, newLeader.Resp.Header.MemberId)
+	fmt.Printf("Requesting leader at %s to transfer leadership to member ID %d...\n", leaderEp, transfereeID)
+	_, err = c.MoveLeader(ctx, transfereeID)
 	if err != nil {
 		return fmt.Errorf("failed to move leader: %w", err)
 	}
 
-	fmt.Println("successfully transferred leadership from", leaderEp, "to", newLeader.Ep)
+	fmt.Println("successfully transferred leadership from", leaderEp, "to member ID ", transfereeID)
 	return nil
 }

--- a/config.go
+++ b/config.go
@@ -11,6 +11,7 @@ type globalConfig struct {
 	endpoints           []string
 	useClusterEndpoints bool
 	excludeLocalhost    bool
+	moveLeader 			bool
 
 	dialTimeout      time.Duration
 	commandTimeout   time.Duration

--- a/main.go
+++ b/main.go
@@ -161,15 +161,15 @@ func defragCommandFunc(cmd *cobra.Command, args []string) {
 				fmt.Printf("Member %q is the leader. Attempting to move the leader...\n", ep)
 
 				// Identify a non-leader member to transfer the leadership
-				var newLeader epStatus
+				newLeaderID := uint64(0)
 				for _, memberStatus := range statusList {
 					if memberStatus.Resp.Header.MemberId != status.Resp.Header.MemberId {
-						newLeader = memberStatus
+						newLeaderID = memberStatus.Resp.Header.MemberId
 						break
 					}
 				}
 
-				if newLeader == (epStatus{}) {
+				if newLeaderID == 0 {
 					failures++
 					fmt.Fprintf(os.Stderr, "Failed to find a non-leader member to transfer leadership from %q.\n", ep)
 					if !globalCfg.continueOnError {
@@ -179,10 +179,10 @@ func defragCommandFunc(cmd *cobra.Command, args []string) {
 				}
 
 				// Perform the leader transfer
-				err = transferLeadership(globalCfg, status.Ep, newLeader)
+				err = transferLeadership(globalCfg, status.Ep, newLeaderID)
 				if err != nil {
 					failures++
-					fmt.Fprintf(os.Stderr, "Failed to move leader from %s to %s: %v\n", status.Ep, newLeader.Ep, err)
+					fmt.Fprintf(os.Stderr, "Failed to move leader from %s to member ID %d: %v\n", status.Ep, newLeaderID, err)
 					if !globalCfg.continueOnError {
 						break
 					}

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ func newDefragCommand() *cobra.Command {
 	defragCmd.Flags().StringSliceVar(&globalCfg.endpoints, "endpoints", []string{"127.0.0.1:2379"}, "comma separated etcd endpoints")
 	defragCmd.Flags().BoolVar(&globalCfg.useClusterEndpoints, "cluster", false, "use all endpoints from the cluster member list")
 	defragCmd.Flags().BoolVar(&globalCfg.excludeLocalhost, "exclude-localhost", false, "whether to exclude localhost endpoints")
+	defragCmd.Flags().BoolVar(&globalCfg.moveLeader, "move-leader", false, "whether to move the leader to a randomly picked non-leader ID and make it the new leader")
 
 	defragCmd.Flags().DurationVar(&globalCfg.dialTimeout, "dial-timeout", 2*time.Second, "dial timeout for client connections")
 	defragCmd.Flags().DurationVar(&globalCfg.commandTimeout, "command-timeout", 30*time.Second, "command timeout (excluding dial timeout)")
@@ -152,6 +153,42 @@ func defragCommandFunc(cmd *cobra.Command, args []string) {
 		if globalCfg.dryRun {
 			fmt.Printf("[Dry run] skip defragmenting endpoint %q\n", ep)
 			continue
+		}
+
+		// Check if the member is a leader and move the leader if necessary
+		if globalCfg.moveLeader {
+			if status.Resp.Leader == status.Resp.Header.MemberId {
+				fmt.Printf("Member %q is the leader. Attempting to move the leader...\n", ep)
+
+				// Identify a non-leader member to transfer the leadership
+				var newLeader epStatus
+				for _, memberStatus := range statusList {
+					if memberStatus.Resp.Header.MemberId != status.Resp.Header.MemberId {
+						newLeader = memberStatus
+						break
+					}
+				}
+
+				if newLeader == (epStatus{}) {
+					failures++
+					fmt.Fprintf(os.Stderr, "Failed to find a non-leader member to transfer leadership from %q.\n", ep)
+					if !globalCfg.continueOnError {
+						break
+					}
+					continue
+				}
+
+				// Perform the leader transfer
+				err = transferLeadership(globalCfg, status.Ep, newLeader)
+				if err != nil {
+					failures++
+					fmt.Fprintf(os.Stderr, "Failed to move leader from %s to %s: %v\n", status.Ep, newLeader.Ep, err)
+					if !globalCfg.continueOnError {
+						break
+					}
+					continue
+				}
+			}
 		}
 
 		fmt.Printf("Defragmenting endpoint %q\n", ep)


### PR DESCRIPTION
- Implemented functionality to check if a member is the leader before defragmentation.
- Added logic to transfer leadership to a non-leader member if the current member is the leader.
- Ensured robust error handling during leader transfer to prevent cluster disruption.
- Integrated the leader transfer step into the defragmentation process with support for `--move-leader` flag.
- Enhanced resilience by allowing continuation on error with the `--continue-on-error` flag.

This change mitigates the risk of outages caused by defragmenting the leader node in an etcd cluster.

Resolves #58 