### PR TITLE
feat: add environment variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ Flags:
       --version                        print the version and exit
 ```
 
+Environment variables can be used to set the flags, by setting the flag name in uppercase and prefixing it with `ETCD_DEFRAG_`. Please note that all hyphens should be replaced with underscores. For example, the flag `--move-leader` can be set with the environment variable `ETCD_DEFRAG_MOVE_LEADER`
+
+Flag values are evaluated in the following order: (from highest to lowest priority)
+
+1. Flags passed as command line arguments
+2. Environment variables
+3. Default values
+
 ## Integration with Kubernetes with a CronJob
 
 It is possible to use [the example cronjob in
@@ -116,9 +124,9 @@ Output:
 Validating configuration.
 No defragmentation rule provided
 Performing health check.
-endpoint: https://127.0.0.1:2379, health: true, took: 4.702492ms, error: 
-endpoint: https://127.0.0.1:22379, health: true, took: 5.017075ms, error: 
-endpoint: https://127.0.0.1:32379, health: true, took: 4.747068ms, error: 
+endpoint: https://127.0.0.1:2379, health: true, took: 4.702492ms, error:
+endpoint: https://127.0.0.1:22379, health: true, took: 5.017075ms, error:
+endpoint: https://127.0.0.1:32379, health: true, took: 4.747068ms, error:
 Getting members status
 endpoint: https://127.0.0.1:2379, dbSize: 172032, dbSizeInUse: 126976, memberId: 8211f1d0f64f3269, leader: 8211f1d0f64f3269, revision: 10365, term: 2, index: 10425
 endpoint: https://127.0.0.1:22379, dbSize: 122880, dbSizeInUse: 122880, memberId: 91bc3c398fb3c146, leader: 8211f1d0f64f3269, revision: 10365, term: 2, index: 10425
@@ -156,8 +164,8 @@ $ etcdctl endpoint status -w table --cluster
 +-------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
 ```
 ## Defragmentation rule
-Defragmentation is an expensive operation, so it should be executed as infrequent as possible. On the other hand, 
-it's also necessary to make sure any etcd member will not run out of the storage quota. It's exactly the reason 
+Defragmentation is an expensive operation, so it should be executed as infrequent as possible. On the other hand,
+it's also necessary to make sure any etcd member will not run out of the storage quota. It's exactly the reason
 why the defragmentation rule is introduced, it can skip unnecessary expensive defragmentation, and also keep
 each member safe.
 
@@ -190,9 +198,9 @@ Output:
 Validating configuration.
 Validating the defragmentation rule: dbSize > dbQuota*80/100 || dbSize - dbSizeInUse > 200*1024*1024 ... valid
 Performing health check.
-endpoint: http://127.0.0.1:2379, health: true, took: 6.993264ms, error: 
-endpoint: http://127.0.0.1:32379, health: true, took: 7.483368ms, error: 
-endpoint: http://127.0.0.1:22379, health: true, took: 49.441931ms, error: 
+endpoint: http://127.0.0.1:2379, health: true, took: 6.993264ms, error:
+endpoint: http://127.0.0.1:32379, health: true, took: 7.483368ms, error:
+endpoint: http://127.0.0.1:22379, health: true, took: 49.441931ms, error:
 Getting members status
 endpoint: http://127.0.0.1:2379, dbSize: 131072, dbSizeInUse: 131072, memberId: 8211f1d0f64f3269, leader: 8211f1d0f64f3269, revision: 10964, term: 2, index: 11028
 endpoint: http://127.0.0.1:22379, dbSize: 131072, dbSizeInUse: 131072, memberId: 91bc3c398fb3c146, leader: 8211f1d0f64f3269, revision: 10964, term: 2, index: 11028

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllFlags(t *testing.T) {
+	testCases := []struct {
+		name string
+		env  map[string]string
+		cli  []string
+		want globalConfig
+	}{
+		{
+			name: "defaults only",
+			env:  nil,
+			cli:  nil,
+			want: globalConfig{
+				endpoints:           []string{"127.0.0.1:2379"},
+				useClusterEndpoints: false,
+				excludeLocalhost:    false,
+				moveLeader:          false,
+				dialTimeout:         2 * time.Second,
+				commandTimeout:      30 * time.Second,
+				keepAliveTime:       2 * time.Second,
+				keepAliveTimeout:    6 * time.Second,
+				insecure:            true,
+				insecureSkepVerify:  false,
+				certFile:            "",
+				keyFile:             "",
+				caFile:              "",
+				username:            "",
+				password:            "",
+				dnsDomain:           "",
+				dnsService:          "",
+				insecureDiscovery:   true,
+				compaction:          true,
+				continueOnError:     true,
+				dbQuotaBytes:        2 * 1024 * 1024 * 1024,
+				defragRule:          "",
+				printVersion:        false,
+				dryRun:              false,
+			},
+		},
+		{
+			name: "all from environment",
+			env: map[string]string{
+				"ETCD_DEFRAG_ENDPOINTS":                "10.0.0.1:2379,10.0.0.2:2379",
+				"ETCD_DEFRAG_CLUSTER":                  "true",
+				"ETCD_DEFRAG_EXCLUDE_LOCALHOST":        "true",
+				"ETCD_DEFRAG_MOVE_LEADER":              "true",
+				"ETCD_DEFRAG_DIAL_TIMEOUT":             "5s",
+				"ETCD_DEFRAG_COMMAND_TIMEOUT":          "45s",
+				"ETCD_DEFRAG_KEEPALIVE_TIME":           "3s",
+				"ETCD_DEFRAG_KEEPALIVE_TIMEOUT":        "8s",
+				"ETCD_DEFRAG_INSECURE_TRANSPORT":       "false",
+				"ETCD_DEFRAG_INSECURE_SKIP_TLS_VERIFY": "true",
+				"ETCD_DEFRAG_CERT":                     "/path/to/cert",
+				"ETCD_DEFRAG_KEY":                      "/path/to/key",
+				"ETCD_DEFRAG_CACERT":                   "/path/to/ca",
+				"ETCD_DEFRAG_USER":                     "envuser",
+				"ETCD_DEFRAG_PASSWORD":                 "envpassword",
+				"ETCD_DEFRAG_DISCOVERY_SRV":            "mydomain.com",
+				"ETCD_DEFRAG_DISCOVERY_SRV_NAME":       "etcd",
+				"ETCD_DEFRAG_INSECURE_DISCOVERY":       "false",
+				"ETCD_DEFRAG_COMPACTION":               "false",
+				"ETCD_DEFRAG_CONTINUE_ON_ERROR":        "false",
+				"ETCD_DEFRAG_ETCD_STORAGE_QUOTA_BYTES": "1073741824",
+				"ETCD_DEFRAG_DEFRAG_RULE":              "size(db) > 500MB",
+				"ETCD_DEFRAG_VERSION":                  "true",
+				"ETCD_DEFRAG_DRY_RUN":                  "true",
+			},
+			cli: nil,
+			want: globalConfig{
+				endpoints:           []string{"10.0.0.1:2379", "10.0.0.2:2379"},
+				useClusterEndpoints: true,
+				excludeLocalhost:    true,
+				moveLeader:          true,
+				dialTimeout:         5 * time.Second,
+				commandTimeout:      45 * time.Second,
+				keepAliveTime:       3 * time.Second,
+				keepAliveTimeout:    8 * time.Second,
+				insecure:            false,
+				insecureSkepVerify:  true,
+				certFile:            "/path/to/cert",
+				keyFile:             "/path/to/key",
+				caFile:              "/path/to/ca",
+				username:            "envuser",
+				password:            "envpassword",
+				dnsDomain:           "mydomain.com",
+				dnsService:          "etcd",
+				insecureDiscovery:   false,
+				compaction:          false,
+				continueOnError:     false,
+				dbQuotaBytes:        1073741824,
+				defragRule:          "size(db) > 500MB",
+				printVersion:        true,
+				dryRun:              true,
+			},
+		},
+		{
+			name: "all from CLI (override environment)",
+			env: map[string]string{
+				"ETCD_DEFRAG_ENDPOINTS":          "shouldBeOverridden:9999",
+				"ETCD_DEFRAG_CLUSTER":            "false",
+				"ETCD_DEFRAG_MOVE_LEADER":        "false",
+				"ETCD_DEFRAG_INSECURE_TRANSPORT": "true",
+			},
+			cli: []string{
+				"--endpoints=192.168.1.100:2379,192.168.1.101:2379",
+				"--cluster=true",
+				"--exclude-localhost=true",
+				"--move-leader=true",
+				"--dial-timeout=7s",
+				"--command-timeout=50s",
+				"--keepalive-time=4s",
+				"--keepalive-timeout=10s",
+				"--insecure-transport=false",
+				"--insecure-skip-tls-verify=true",
+				"--cert=/cli/cert",
+				"--key=/cli/key",
+				"--cacert=/cli/ca",
+				"--user=cliuser",
+				"--password=clipass",
+				"--discovery-srv=cli.mydomain",
+				"--discovery-srv-name=clietcd",
+				"--insecure-discovery=false",
+				"--compaction=false",
+				"--continue-on-error=false",
+				"--etcd-storage-quota-bytes=999999999",
+				"--defrag-rule=size(db) >= 1GB",
+				"--version=true",
+				"--dry-run=true",
+			},
+			want: globalConfig{
+				endpoints:           []string{"192.168.1.100:2379", "192.168.1.101:2379"},
+				useClusterEndpoints: true,
+				excludeLocalhost:    true,
+				moveLeader:          true,
+				dialTimeout:         7 * time.Second,
+				commandTimeout:      50 * time.Second,
+				keepAliveTime:       4 * time.Second,
+				keepAliveTimeout:    10 * time.Second,
+				insecure:            false,
+				insecureSkepVerify:  true,
+				certFile:            "/cli/cert",
+				keyFile:             "/cli/key",
+				caFile:              "/cli/ca",
+				username:            "cliuser",
+				password:            "clipass",
+				dnsDomain:           "cli.mydomain",
+				dnsService:          "clietcd",
+				insecureDiscovery:   false,
+				compaction:          false,
+				continueOnError:     false,
+				dbQuotaBytes:        999999999,
+				defragRule:          "size(db) >= 1GB",
+				printVersion:        true,
+				dryRun:              true,
+			},
+		},
+		{
+			name: "mixed env + CLI",
+			env: map[string]string{
+				"ETCD_DEFRAG_ENDPOINTS":                "env:2379",
+				"ETCD_DEFRAG_CLUSTER":                  "false",
+				"ETCD_DEFRAG_MOVE_LEADER":              "true",
+				"ETCD_DEFRAG_COMPACTION":               "false",
+				"ETCD_DEFRAG_ETCD_STORAGE_QUOTA_BYTES": "555555555",
+			},
+			cli: []string{
+				"--exclude-localhost=true", // override the default
+				"--dial-timeout=10s",       // override the default
+				"--compaction=true",        // override the env
+			},
+			want: globalConfig{
+				endpoints:           []string{"env:2379"},
+				useClusterEndpoints: false, // env sets cluster=false
+				excludeLocalhost:    true,  // from CLI
+				moveLeader:          true,  // from env
+				dialTimeout:         10 * time.Second,
+				commandTimeout:      30 * time.Second, // default
+				keepAliveTime:       2 * time.Second,  // default
+				keepAliveTimeout:    6 * time.Second,  // default
+				insecure:            true,             // default
+				insecureSkepVerify:  false,            // default
+				certFile:            "",
+				keyFile:             "",
+				caFile:              "",
+				username:            "",
+				password:            "",
+				dnsDomain:           "",
+				dnsService:          "",
+				insecureDiscovery:   true,
+				compaction:          true,      // CLI override
+				continueOnError:     true,      // default
+				dbQuotaBytes:        555555555, // from env
+				defragRule:          "",
+				printVersion:        false, // default
+				dryRun:              false, // default
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			viper.Reset()
+			os.Clearenv()
+
+			for key, val := range tc.env {
+				if err := os.Setenv(key, val); err != nil {
+					t.Fatalf("failed to set env %s=%s: %v", key, val, err)
+				}
+			}
+
+			cmd := newDefragCommand()
+			// Set empty Run function to avoid actual execution
+			cmd.Run = func(cmd *cobra.Command, args []string) {}
+
+			if tc.cli != nil {
+				cmd.SetArgs(tc.cli)
+			}
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("command execution failed: %v", err)
+			}
+
+			require.Equal(t, tc.want, globalCfg)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/maja42/goval v1.6.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.19.0
+	github.com/stretchr/testify v1.9.0
 	go.etcd.io/etcd/api/v3 v3.6.0-alpha.0.0.20240409070941-65ac859a1b61
 	go.etcd.io/etcd/client/pkg/v3 v3.6.0-alpha.0.0.20240409070941-65ac859a1b61
 	go.etcd.io/etcd/client/v3 v3.6.0-alpha.0.0.20240409070941-65ac859a1b61
@@ -18,6 +19,7 @@ require (
 require (
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
@@ -27,6 +29,7 @@ require (
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect

--- a/main.go
+++ b/main.go
@@ -25,6 +25,10 @@ func newDefragCommand() *cobra.Command {
 		},
 		Run: defragCommandFunc,
 	}
+
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	viper.SetEnvPrefix("ETCD_DEFRAG")
+	viper.AutomaticEnv()
 	setDefaults()
 
 	// Manually splitting, because GetStringSlice has inconsistent behavior for splitting command line flags and environment variables


### PR DESCRIPTION
#### Context
etcdctl supports variables for it's flags via ETCDCTL_ prefix, it could be useful to have it here for setting up automated workflows where environment is already predefined

#### Proposal
Since viper library is used it can be adapted to to easily import appropriate environment variables for each of the command line flag

#### Changes
- Adding environment variable import for `ETCD_DEFRAG_` prefix
- Unit tests for command line flag value precedence

PR 2/2 of adding environment variable support
