### PR TITLE
feat: add new flag wait-between-defrags

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ It adds the following extra flags,
 | `--dry-run`                  | evaluate whether or not endpoints require defragmentation, but don't actually perform it, defaults to `false`. |
 | `--exclude-localhost`        | whether to exclude localhost endpoints, defaults to `false`. |
 | `--move-leader`              | whether to move the leadership before performing defragmentation on the leader, defaults to `false`. |
+| `--wait-between-defrags`     | wait time between consecutive defragmentation runs or after a leader movement (if --move-leader is enabled). Defaults to 0s (no wait) |
 | `--skip-healthcheck-cluster-endpoints` | skip cluster endpoint discovery during health check and only check the endpoints provided via --endpoints, defaults to `false`. |
 
 See the complete flags below,
@@ -75,6 +76,7 @@ Flags:
       --move-leader                          whether to move the leadership before performing defragmentation on the leader
       --password string                      password for authentication (if this option is used, --user option shouldn't include password)
       --skip-healthcheck-cluster-endpoints   skip cluster endpoint discovery during health check and only check the endpoints provided via --endpoints
+      --wait-between-defrags                 wait time between consecutive defragmentation runs or after a leader movement (if --move-leader is enabled). Defaults to 0s (no wait)
       --user string                          username[:password] for authentication (prompt if password is not supplied)
       --version                              print the version and exit
 ```

--- a/config.go
+++ b/config.go
@@ -12,6 +12,7 @@ type globalConfig struct {
 	useClusterEndpoints bool
 	excludeLocalhost    bool
 	moveLeader          bool
+	waitPeriod          time.Duration
 
 	dialTimeout      time.Duration
 	commandTimeout   time.Duration


### PR DESCRIPTION
### Add --wait-between-defrags flag to control defrag interval

**Problem**

Currently, the `etcd-defrag` tool executes defragmentation operations on cluster members sequentially without a configurable delay. In environments with high write loads or large databases, back-to-back defragmentation across multiple members can introduce performance overhead and potentially impact cluster stability.

This risk is amplified when the defragmented member is the cluster leader. The subsequent leader election process takes time, and starting another defragmentation immediately on a different member can interfere with the cluster's ability to cleanly establish new leadership and return to a stable state. Without a pause, the cluster might face compounded stress, increasing the risk of performance degradation or temporary unavailability.

**Solution**

This pull request introduces a new `--wait-between-defrags` flag to the `etcd-defrag` command. This flag allows operators to specify a duration to wait between defragmenting each member of the etcd cluster. Introducing a configurable wait period provides greater control over the defragmentation process, enabling users to mitigate performance impacts on busy clusters.

By spacing out the defragmentation of individual members, the cluster is given time to stabilize and recover, ensuring that the overall operational health is maintained throughout the maintenance process.

Crucially, this wait period also provides a sufficient window for the cluster to complete a new leader election and stabilize if the defragmented member was the leader. This prevents compounding instability by ensuring a healthy leader is firmly in place before proceeding to the next member. This approach is particularly beneficial in production environments where maintaining high availability and predictable performance is critical.

**Usage Examples**

**Default Behavior (Backwards Compatible)**

If the `--wait-between-defrags` flag is not specified, the tool will continue to defragment members sequentially without any delay, preserving the existing behavior.
```bash
etcd-defrag --endpoints=192.168.1.10:2379```

**New Flag Enabled**

To introduce a 60-second delay between the defragmentation of each cluster member—providing ample time for potential leader election and stabilization—the following command can be used:
```bash
etcd-defrag --endpoints=192.168.1.10:2379 --wait-between-defrags=60s