### PR TITLE
feat: add new flag auto-disalarm and disalarm-threshold

### DIFF
--- a/agent_test.go
+++ b/agent_test.go
@@ -158,6 +158,104 @@ func TestEndpointsFromCluster_ExcludesLearners(t *testing.T) {
 	}
 }
 
+func TestCheckAllMembersDBSize(t *testing.T) {
+	testCases := []struct {
+		name             string
+		gcfg             globalConfig
+		statusList       []epStatus
+		expectedEps      []string
+		expectedAllBelow bool
+	}{
+		{
+			name: "all members below threshold",
+			gcfg: globalConfig{
+				dbQuotaBytes:      1000,
+				disalarmThreshold: 0.8,
+			},
+			statusList: []epStatus{
+				{Ep: "ep1", Resp: &clientv3.StatusResponse{DbSize: 700}},
+				{Ep: "ep2", Resp: &clientv3.StatusResponse{DbSize: 600}},
+				{Ep: "ep3", Resp: &clientv3.StatusResponse{DbSize: 500}},
+			},
+			expectedEps:      nil,
+			expectedAllBelow: true,
+		},
+		{
+			name: "some members above threshold",
+			gcfg: globalConfig{
+				dbQuotaBytes:      1000,
+				disalarmThreshold: 0.8,
+			},
+			statusList: []epStatus{
+				{Ep: "ep1", Resp: &clientv3.StatusResponse{DbSize: 900}},
+				{Ep: "ep2", Resp: &clientv3.StatusResponse{DbSize: 850}},
+				{Ep: "ep3", Resp: &clientv3.StatusResponse{DbSize: 500}},
+			},
+			expectedEps:      []string{"ep1", "ep2"},
+			expectedAllBelow: false,
+		},
+		{
+			name: "all members above threshold",
+			gcfg: globalConfig{
+				dbQuotaBytes:      1000,
+				disalarmThreshold: 0.5,
+			},
+			statusList: []epStatus{
+				{Ep: "ep1", Resp: &clientv3.StatusResponse{DbSize: 600}},
+				{Ep: "ep2", Resp: &clientv3.StatusResponse{DbSize: 700}},
+				{Ep: "ep3", Resp: &clientv3.StatusResponse{DbSize: 800}},
+			},
+			expectedEps:      []string{"ep1", "ep2", "ep3"},
+			expectedAllBelow: false,
+		},
+		{
+			name: "empty status list",
+			gcfg: globalConfig{
+				dbQuotaBytes:      1000,
+				disalarmThreshold: 0.8,
+			},
+			statusList:       []epStatus{},
+			expectedEps:      nil,
+			expectedAllBelow: true,
+		},
+		{
+			name: "zero threshold",
+			gcfg: globalConfig{
+				dbQuotaBytes:      1000,
+				disalarmThreshold: 0.0,
+			},
+			statusList: []epStatus{
+				{Ep: "ep1", Resp: &clientv3.StatusResponse{DbSize: 100}},
+				{Ep: "ep2", Resp: &clientv3.StatusResponse{DbSize: 50}},
+			},
+			expectedEps:      []string{"ep1", "ep2"},
+			expectedAllBelow: false,
+		},
+		{
+			name: "threshold at boundary",
+			gcfg: globalConfig{
+				dbQuotaBytes:      1000,
+				disalarmThreshold: 0.8,
+			},
+			statusList: []epStatus{
+				{Ep: "ep1", Resp: &clientv3.StatusResponse{DbSize: 800}}, // exactly at threshold
+				{Ep: "ep2", Resp: &clientv3.StatusResponse{DbSize: 801}}, // just above threshold
+			},
+			expectedEps:      []string{"ep2"},
+			expectedAllBelow: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			eps, allBelow := checkAllMembersDBSize(tc.gcfg, tc.statusList)
+
+			require.Equal(t, tc.expectedEps, eps, "unexpected endpoints above threshold")
+			require.Equal(t, tc.expectedAllBelow, allBelow, "unexpected allBelow result")
+		})
+	}
+}
+
 type fakeHealthCheckClient struct {
 	*clientv3.Client
 	memberListResp *clientv3.MemberListResponse

--- a/config.go
+++ b/config.go
@@ -45,6 +45,9 @@ type globalConfig struct {
 	dryRun bool
 
 	skipHealthcheckClusterEndpoints bool
+
+	autoDisalarm      bool
+	disalarmThreshold float64
 }
 
 func clientConfigWithoutEndpoints(gcfg globalConfig) *clientv3.ConfigSpec {

--- a/main.go
+++ b/main.go
@@ -73,6 +73,9 @@ func newDefragCommand() *cobra.Command {
 
 	defragCmd.Flags().BoolVar(&globalCfg.skipHealthcheckClusterEndpoints, "skip-healthcheck-cluster-endpoints", viper.GetBool("skip-healthcheck-cluster-endpoints"), "skip cluster endpoint discovery during health check and only check the endpoints provided via --endpoints")
 
+	defragCmd.Flags().BoolVar(&globalCfg.autoDisalarm, "auto-disalarm", viper.GetBool("auto-disalarm"), "whether automatically disalarm NOSPACE alarms after successful defragmentation，defaults to false")
+	defragCmd.Flags().Float64Var(&globalCfg.disalarmThreshold, "disalarm-threshold", viper.GetFloat64("disalarm-threshold"), "Threshold ratio for automatic alarm clearing (db size / quota). Valid range: 0 < x < 1 (default: 0.9)")
+
 	return defragCmd
 }
 
@@ -103,6 +106,8 @@ func setDefaults() {
 	viper.SetDefault("version", false)
 	viper.SetDefault("dry-run", false)
 	viper.SetDefault("skip-healthcheck-cluster-endpoints", false)
+	viper.SetDefault("auto-disalarm", false)
+	viper.SetDefault("disalarm-threshold", 0.9)
 }
 
 func main() {
@@ -256,6 +261,20 @@ func defragCommandFunc(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 	log.Println("The defragmentation is successful.")
+
+	// Perform auto-disalarm if enabled and not in dry-run mode
+	if !globalCfg.dryRun && globalCfg.autoDisalarm {
+		log.Println("Start auto-disalarm")
+		// Get updated status after defragmentation
+		updatedStatusList, err := getMembersStatus(globalCfg)
+		if err != nil {
+			log.Printf("Failed to get updated members status for auto-disalarm: %v\n", err)
+		} else {
+			if err := performAutoDisalarm(globalCfg, updatedStatusList); err != nil {
+				log.Printf("Auto-disalarm failed: %v\n", err)
+			}
+		}
+	}
 }
 
 func validateConfig(cmd *cobra.Command, gcfg globalConfig) error {
@@ -293,6 +312,18 @@ func validateConfig(cmd *cobra.Command, gcfg globalConfig) error {
 
 	if gcfg.skipHealthcheckClusterEndpoints && gcfg.dnsDomain != "" {
 		return errors.New("--skip-healthcheck-cluster-endpoints and --discovery-srv flags are mutually exclusive")
+	}
+
+	if gcfg.autoDisalarm && gcfg.disalarmThreshold <= 0 {
+		return errors.New("--disalarm-threshold must be greater than 0 when --auto-disalarm is enabled")
+	}
+
+	if gcfg.autoDisalarm && gcfg.disalarmThreshold > 1 {
+		return errors.New("--disalarm-threshold must be less than 1.0 when --auto-disalarm is enabled")
+	}
+
+	if gcfg.disalarmThreshold != 0 && !gcfg.autoDisalarm {
+		log.Println("Warning: --disalarm-threshold is set but --auto-disalarm is disabled, threshold will be ignored")
 	}
 
 	return nil


### PR DESCRIPTION
### backgroud
see https://github.com/ahrtr/etcd-defrag/issues/120

### Solution
This pull request introduces a new --auto-disalarm flag to the etcd-defrag command. This flag enables automatic detection and clearing of NOSPACE alarms after successful defragmentation operations. The feature includes a configurable threshold (--disalarm-threshold) that determines when alarms should be cleared based on the ratio of current database size to storage quota.

By automating the alarm clearing process, this feature eliminates the need for manual intervention, reduces operational overhead, and ensures clusters return to healthy states more quickly after defragmentation. The configurable threshold provides flexibility to accommodate different operational requirements and safety margins.

The automatic alarm clearing is performed only after successful defragmentation and when the database size falls below the specified threshold relative to the storage quota. This ensures that alarms are cleared only when the cluster has genuinely recovered from the space constraint condition.

**Default Behavior (Backwards Compatible)**

If the --auto-disalarm flag is not specified, the tool will perform defragmentation without any automatic alarm clearing, preserving the existing behavior and requiring manual intervention for alarm management.

```bash
etcd-defrag --endpoints=192.168.1.10:2379
```

**Basic Auto-disalarm Enabled**

To enable automatic alarm clearing with the default threshold (0.9), ensuring alarms are cleared when database size falls below 90% of quota:

```bash
etcd-defrag --endpoints=192.168.1.10:2379 --auto-disalarm
```

**Custom Threshold Configuration**

To enable automatic alarm clearing with a more conservative threshold, clearing alarms only when database size falls below 80% of quota:

```bash
etcd-defrag --endpoints=192.168.1.10:2379 --auto-disalarm --disalarm-threshold=0.8
```