### PR TITLE
feat: auto disalarm

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ etcd-defrag
   - [Example 2: run defragmentation on multiple endpoints](#example-2-run-defragmentation-on-multiple-endpoints)
   - [Example 3: run defragmentation on all members in the cluster](#example-3-run-defragmentation-on-all-members-in-the-cluster)
 - [Defragmentation rule](#defragmentation-rule)
+- [Auto-disalarm Feature](#auto-disalarm-feature)
 - [Container image](#container-image)
 - [Contributing](#contributing)
 - [Note](#note)
@@ -42,6 +43,8 @@ It adds the following extra flags,
 | `--move-leader`              | whether to move the leadership before performing defragmentation on the leader, defaults to `false`. |
 | `--wait-between-defrags`     | wait time between consecutive defragmentation runs or after a leader movement (if --move-leader is enabled). Defaults to 0s (no wait) |
 | `--skip-healthcheck-cluster-endpoints` | skip cluster endpoint discovery during health check and only check the endpoints provided via --endpoints, defaults to `false`. |
+| `--auto-disalarm`            | automatically disalarm NOSPACE alarms after successful defragmentation, defaults to `false`. |
+| `--disalarm-threshold`       | threshold ratio for auto-disalarm (db size / quota), only disalarm when all members are below this threshold, defaults to `0.9`. |
 
 See the complete flags below,
 ```
@@ -78,6 +81,8 @@ Flags:
       --skip-healthcheck-cluster-endpoints   skip cluster endpoint discovery during health check and only check the endpoints provided via --endpoints
       --wait-between-defrags                 wait time between consecutive defragmentation runs or after a leader movement (if --move-leader is enabled). Defaults to 0s (no wait)
       --user string                          username[:password] for authentication (prompt if password is not supplied)
+      --auto-disalarm                        whether automatically disalarm NOSPACE alarms after successful defragmentation（default false）
+      --disalarm-threshold float             threshold ratio for automatic alarm clearing (db size / quota). Valid range: 0 < x < 1 (default: 0.9)
       --version                              print the version and exit
 ```
 
@@ -174,6 +179,7 @@ $ etcdctl endpoint status -w table --cluster
 | https://127.0.0.1:32379 | fd422379fda50e48 |   3.5.8 |   25 kB |     false |      false |        10 |        164 |                164 |        |
 +-------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
 ```
+
 ## Defragmentation rule
 Defragmentation is an expensive operation, so it should be executed as infrequent as possible. On the other hand,
 it's also necessary to make sure any etcd member will not run out of the storage quota. It's exactly the reason
@@ -237,6 +243,47 @@ of the quota **AND** there is at least 200MiB free space, then run command below
 ```
 $ ./etcd-defrag --endpoints http://127.0.0.1:22379 --cluster --defrag-rule="dbSize > dbQuota*80/100 && dbSize - dbSizeInUse > 200*1024*1024"
 ```
+
+## Auto-disalarm Feature
+
+The auto-disalarm feature automatically removes NOSPACE alarms if any after successful defragmentation when certain conditions are met. This helps maintain cluster health by clearing alarms that are no longer relevant after freeing up space through defragmentation.
+
+### How it works
+
+When `--auto-disalarm` is enabled, etcd-defrag will:
+
+1. Check if there are any NOSPACE alarms in the cluster after defragmentation
+2. Verify that all cluster members' database size is below the specified threshold
+3. Automatically disalarm NOSPACE alarms if both conditions are met
+
+### Configuration
+
+- `--auto-disalarm`: whether automatically disalarm NOSPACE alarms after successful defragmentation（default false）
+- `--disalarm-threshold`: Threshold ratio for automatic alarm clearing (db size / quota). Valid range: 0 < x < 1 (default: 0.9)
+
+### Example Usage
+
+```bash
+# Enable auto-disalarm with default threshold (0.9)
+$ ./etcd-defrag --endpoints=https://127.0.0.1:2379 --cluster --auto-disalarm
+
+# Enable auto-disalarm with custom threshold (0.7)
+$ ./etcd-defrag --endpoints=https://127.0.0.1:2379 --cluster --auto-disalarm --disalarm-threshold=0.7
+```
+
+### Safety Considerations
+
+- Auto-disalarm only triggers when **all** cluster members's DB sizes are below the threshold.
+
+- The threshold is highly dependent on the **--etcd-storage-quota-bytes** flag, which defaults to `2147483648` (2 GiB) in `etcd-defrag`. The formula is as follows:
+  ```
+  threshold = etcd-storage-quota-bytes * disalarm-threshold
+  ```
+  Please ensure that you provide the correct value; otherwise, unexpected behavior may occur, such as the disalarm operation not being triggered.
+
+- This feature only affects **NOSPACE** alarms; other alarm types are not affected.
+
+- The value of --disalarm-threshold must be between **0 and 1.0** (0 < x < 1).
 
 ## Container image
 Container images are released automatically using GitHub actions and [`ko-build/ko`](https://github.com/ko-build/ko).

--- a/agent_test.go
+++ b/agent_test.go
@@ -158,6 +158,96 @@ func TestEndpointsFromCluster_ExcludesLearners(t *testing.T) {
 	}
 }
 
+func TestCheckAllMembersDBSize(t *testing.T) {
+	testCases := []struct {
+		name        string
+		gcfg        globalConfig
+		statusList  []epStatus
+		expectedEps []string
+	}{
+		{
+			name: "all members below threshold",
+			gcfg: globalConfig{
+				dbQuotaBytes:      1000,
+				disalarmThreshold: 0.8,
+			},
+			statusList: []epStatus{
+				{Ep: "ep1", Resp: &clientv3.StatusResponse{DbSize: 700}},
+				{Ep: "ep2", Resp: &clientv3.StatusResponse{DbSize: 600}},
+				{Ep: "ep3", Resp: &clientv3.StatusResponse{DbSize: 500}},
+			},
+			expectedEps: nil,
+		},
+		{
+			name: "some members above threshold",
+			gcfg: globalConfig{
+				dbQuotaBytes:      1000,
+				disalarmThreshold: 0.8,
+			},
+			statusList: []epStatus{
+				{Ep: "ep1", Resp: &clientv3.StatusResponse{DbSize: 900}},
+				{Ep: "ep2", Resp: &clientv3.StatusResponse{DbSize: 850}},
+				{Ep: "ep3", Resp: &clientv3.StatusResponse{DbSize: 500}},
+			},
+			expectedEps: []string{"ep1", "ep2"},
+		},
+		{
+			name: "all members above threshold",
+			gcfg: globalConfig{
+				dbQuotaBytes:      1000,
+				disalarmThreshold: 0.5,
+			},
+			statusList: []epStatus{
+				{Ep: "ep1", Resp: &clientv3.StatusResponse{DbSize: 600}},
+				{Ep: "ep2", Resp: &clientv3.StatusResponse{DbSize: 700}},
+				{Ep: "ep3", Resp: &clientv3.StatusResponse{DbSize: 800}},
+			},
+			expectedEps: []string{"ep1", "ep2", "ep3"},
+		},
+		{
+			name: "empty status list",
+			gcfg: globalConfig{
+				dbQuotaBytes:      1000,
+				disalarmThreshold: 0.8,
+			},
+			statusList:  []epStatus{},
+			expectedEps: nil,
+		},
+		{
+			name: "zero threshold",
+			gcfg: globalConfig{
+				dbQuotaBytes:      1000,
+				disalarmThreshold: 0.0,
+			},
+			statusList: []epStatus{
+				{Ep: "ep1", Resp: &clientv3.StatusResponse{DbSize: 100}},
+				{Ep: "ep2", Resp: &clientv3.StatusResponse{DbSize: 50}},
+			},
+			expectedEps: []string{"ep1", "ep2"},
+		},
+		{
+			name: "threshold at boundary",
+			gcfg: globalConfig{
+				dbQuotaBytes:      1000,
+				disalarmThreshold: 0.8,
+			},
+			statusList: []epStatus{
+				{Ep: "ep1", Resp: &clientv3.StatusResponse{DbSize: 800}}, // exactly at threshold
+				{Ep: "ep2", Resp: &clientv3.StatusResponse{DbSize: 801}}, // just above threshold
+			},
+			expectedEps: []string{"ep2"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			eps := checkAllMembersDBSize(tc.gcfg, tc.statusList)
+
+			require.ElementsMatch(t, tc.expectedEps, eps, "unexpected endpoints above threshold")
+		})
+	}
+}
+
 type fakeHealthCheckClient struct {
 	*clientv3.Client
 	memberListResp *clientv3.MemberListResponse

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -46,6 +46,8 @@ func TestAllFlags(t *testing.T) {
 				defragRule:          "",
 				printVersion:        false,
 				dryRun:              false,
+				autoDisalarm:        false,
+				disalarmThreshold:   0.9,
 			},
 		},
 		{
@@ -75,6 +77,8 @@ func TestAllFlags(t *testing.T) {
 				"ETCD_DEFRAG_DEFRAG_RULE":              "size(db) > 500MB",
 				"ETCD_DEFRAG_VERSION":                  "true",
 				"ETCD_DEFRAG_DRY_RUN":                  "true",
+				"ETCD_DEFRAG_AUTO_DISALARM":            "false",
+				"ETCD_DEFRAG_DISALARM_THRESHOLD":       "0.9",
 			},
 			cli: nil,
 			want: globalConfig{
@@ -102,6 +106,8 @@ func TestAllFlags(t *testing.T) {
 				defragRule:          "size(db) > 500MB",
 				printVersion:        true,
 				dryRun:              true,
+				autoDisalarm:        false,
+				disalarmThreshold:   0.9,
 			},
 		},
 		{
@@ -163,6 +169,8 @@ func TestAllFlags(t *testing.T) {
 				defragRule:          "size(db) >= 1GB",
 				printVersion:        true,
 				dryRun:              true,
+				autoDisalarm:        false,
+				disalarmThreshold:   0.9,
 			},
 		},
 		{
@@ -204,6 +212,8 @@ func TestAllFlags(t *testing.T) {
 				defragRule:          "",
 				printVersion:        false, // default
 				dryRun:              false, // default
+				autoDisalarm:        false, // default
+				disalarmThreshold:   0.9,
 			},
 		},
 	}

--- a/config.go
+++ b/config.go
@@ -45,6 +45,9 @@ type globalConfig struct {
 	dryRun bool
 
 	skipHealthcheckClusterEndpoints bool
+
+	autoDisalarm      bool
+	disalarmThreshold float64
 }
 
 func clientConfigWithoutEndpoints(gcfg globalConfig) *clientv3.ConfigSpec {

--- a/disalarm.go
+++ b/disalarm.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"log"
+)
+
+// performAutoDisalarm performs automatic disalarm operation
+func performAutoDisalarm(gcfg globalConfig, statusList []epStatus) error {
+	alarms, err := noSpaceAlarms(gcfg)
+	if err != nil {
+		return fmt.Errorf("failed to get NOSPACE alarms: %w", err)
+	}
+
+	if len(alarms) == 0 {
+		log.Println("No NOSPACE alarms found, skipping auto-disalarm")
+		return nil
+	}
+
+	log.Println("Found NOSPACE alarms")
+
+	// Check if all members' DB size is below threshold
+	epsWithDBSize := checkAllMembersDBSize(gcfg, statusList)
+	if len(epsWithDBSize) > 0 {
+		log.Printf("Members %v DB size is still above threshold (%.2f), skipping auto-disalarm\n", epsWithDBSize, gcfg.disalarmThreshold)
+		return nil
+	}
+
+	log.Println("Performing auto-disalarm operation...")
+	if err := disAlarmNoSpaceAlarms(gcfg, alarms); err != nil {
+		return fmt.Errorf("failed to disalarm NOSPACE alarms: %w", err)
+	}
+
+	log.Println("Auto-disalarm operation completed successfully")
+	return nil
+}
+
+// checkAllMembersDBSize checks if all members' DB size is below the threshold
+func checkAllMembersDBSize(gcfg globalConfig, statusList []epStatus) []string {
+	var eps []string
+	threshold := float64(gcfg.dbQuotaBytes) * gcfg.disalarmThreshold
+	for _, status := range statusList {
+		if float64(status.Resp.DbSize) > threshold {
+			eps = append(eps, status.Ep)
+		}
+	}
+	return eps
+}


### PR DESCRIPTION
### backgroud
see https://github.com/ahrtr/etcd-defrag/issues/120

### Solution
This pull request introduces a new --auto-disalarm flag to the etcd-defrag command. This flag enables automatic detection and clearing of NOSPACE alarms after successful defragmentation operations. The feature includes a configurable threshold (--disalarm-threshold) that determines when alarms should be cleared based on the ratio of current database size to storage quota.

By automating the alarm clearing process, this feature eliminates the need for manual intervention, reduces operational overhead, and ensures clusters return to healthy states more quickly after defragmentation. The configurable threshold provides flexibility to accommodate different operational requirements and safety margins.

The automatic alarm clearing is performed only after successful defragmentation and when the database size falls below the specified threshold relative to the storage quota. This ensures that alarms are cleared only when the cluster has genuinely recovered from the space constraint condition.

**Default Behavior (Backwards Compatible)**

If the --auto-disalarm flag is not specified, the tool will perform defragmentation without any automatic alarm clearing, preserving the existing behavior and requiring manual intervention for alarm management.

```bash
etcd-defrag --endpoints=192.168.1.10:2379
```

**Basic Auto-disalarm Enabled**

To enable automatic alarm clearing with the default threshold (0.9), ensuring alarms are cleared when database size falls below 90% of quota:

```bash
etcd-defrag --endpoints=192.168.1.10:2379 --auto-disalarm
```

**Custom Threshold Configuration**

To enable automatic alarm clearing with a more conservative threshold, clearing alarms only when database size falls below 80% of quota:

```bash
etcd-defrag --endpoints=192.168.1.10:2379 --auto-disalarm --disalarm-threshold=0.8
```